### PR TITLE
KeyValidation created for use with future drivers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "~7.0",
         "psr/simple-cache": "dev-master"
     },
     "require-dev": {

--- a/src/ArrayCache.php
+++ b/src/ArrayCache.php
@@ -5,9 +5,12 @@ namespace Realpage\SimpleCache;
 use Traversable;
 use InvalidArgumentException;
 use Psr\Simplecache\CacheInterface;
+use Realpage\SimpleCache\KeyValidation;
 
 class ArrayCache implements CacheInterface
 {
+    use KeyValidation;
+
     protected $data = [];
 
     public function __construct(array $data = [])
@@ -77,7 +80,6 @@ class ArrayCache implements CacheInterface
         return isset($this->data[$key]);
     }
 
-    // TODO: Move into a CachedItem class eventually
     private function transformKeys($keys)
     {
         if ($keys instanceof Traversable) {
@@ -90,7 +92,7 @@ class ArrayCache implements CacheInterface
         }
 
         throw new InvalidArgumentException(
-            "Cache keys must be of type string and must not contain any of the characters '{}()/@:'"
+            "Cannot call getMultiple with a non array or non Traversable type"
         );
     }
 
@@ -103,19 +105,5 @@ class ArrayCache implements CacheInterface
         }
 
         return $tempKeys;
-    }
-
-    private function validateKey($key)
-    {
-        if ($this->keyFailsRequirements($key)) {
-            throw new InvalidArgumentException(
-                "Cache keys must be of type string and must not contain any of the characters '{}()/@:'"
-            );
-        }
-    }
-
-    private function keyFailsRequirements($key)
-    {
-        return !is_string($key) || strpbrk($key, '{}()/\@:') || strlen($key) === 0;
     }
 }

--- a/src/KeyValidation.php
+++ b/src/KeyValidation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Realpage\SimpleCache;
+
+use InvalidArgumentException;
+use UnexpectedValueException;
+
+trait KeyValidation
+{
+    public function validateKey($key): string
+    {
+        if (!is_string($key)) {
+            throw new InvalidArgumentException(
+                "Cache keys must be a string"
+            );
+        } elseif (strpbrk($key, '{}()/\@:') || strlen($key) === 0) {
+            throw new UnexpectedValueException(
+                "Cache keys must contain at least one character and not contain any of the characters '{}()/@:'"
+            );
+        }
+
+        return $key;
+    }
+}

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -4,6 +4,7 @@ namespace Realpage\SimpleCache\Tests;
 
 use ArrayObject;
 use InvalidArgumentException;
+use UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
 use Realpage\SimpleCache\ArrayCache;
 
@@ -36,7 +37,7 @@ class ArrayCacheTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException UnexpectedValueException
      */
     public function testCannotGetKeyWithInvalidCharacter()
     {

--- a/tests/KeyValidationTest.php
+++ b/tests/KeyValidationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Realpage\SimpleCache\Tests;
+
+use UnexpectedValueException;
+use PHPUnit\Framework\TestCase;
+use Realpage\SimpleCache\KeyValidation;
+
+class KeyValidationTest extends TestCase
+{
+    private $stub;
+
+    public function setUp()
+    {
+        $this->stub = $this->getObjectForTrait(KeyValidation::class);
+    }
+
+    public function testCanReturnAPassingKey()
+    {
+        $this->assertEquals('key1', $this->stub->validateKey('key1'));
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testKeyContainsAtLeastOneCharacter()
+    {
+        $this->stub->validateKey('');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCannotGetUnlessKeyIsString()
+    {
+        $this->stub->validateKey(new \stdClass);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowLeftCurlyBrace()
+    {
+        $this->stub->validateKey('{key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowRightCurlyBrace()
+    {
+        $this->stub->validateKey('}key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowLeftParenthesis()
+    {
+        $this->stub->validateKey('(key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowRightParenthesis()
+    {
+        $this->stub->validateKey(')key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowForwardSlash()
+    {
+        $this->stub->validateKey('/key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowBackslash()
+    {
+        $this->stub->validateKey('\key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowAtSymbol()
+    {
+        $this->stub->validateKey('@key1');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testDoesNotAllowColon()
+    {
+        $this->stub->validateKey(':key1');
+    }
+}


### PR DESCRIPTION
Pulled validation into separate class to help clean up the ArrayCache.
Started to bake this into a CacheItem class, but I think it's best to
wait until there are some other drivers before implementing a CacheItem
with built-in validation